### PR TITLE
Исправил логику раздела Help по замечаниям

### DIFF
--- a/drevo/templates/help/help.html
+++ b/drevo/templates/help/help.html
@@ -18,7 +18,7 @@
 </ul>
 <div class="row">
   <div class="col">
-    {{ context.content }}
+    {{ context.content | safe }}
   </div>
 </div>
 {% endblock %}

--- a/help/views.py
+++ b/help/views.py
@@ -11,14 +11,13 @@ def help(request, category=None):
             return render(request, "help/help.html", {"context": context, "nodes": nodes})
     url_redirect = request.META.get('HTTP_REFERER')
     try:
-        try:
-            url_tag = re.search(r"(?<=drevo)/\w+|/$", url_redirect).group(0)
-        except AttributeError:
-            context = HelpPage.objects.filter(category__url_tag='/', category__is_published=True).first()
-            return render(request, "help/help.html", {"context": context, "nodes": nodes})
+        url_tag = re.search(r"(?<=drevo)/\w+|/$", url_redirect).group(0)
         context = HelpPage.objects.filter(category__url_tag=url_tag, category__is_published=True).first()
         if context:
             return render(request, "help/help.html", {"context": context, "nodes": nodes})
+    except AttributeError:
+        context = HelpPage.objects.filter(category__url_tag='/', category__is_published=True).first()
+        return render(request, "help/help.html", {"context": context, "nodes": nodes})
     except Exception:
         return render(request, "help/help_404.html", {'nodes': nodes})
     return render(request, "help/help_404.html", {'nodes': nodes})

--- a/help/views.py
+++ b/help/views.py
@@ -4,14 +4,18 @@ from .models import HelpPage, CategoryHelp
 
 
 def help(request, category=None):
-    nodes = CategoryHelp.objects.all()
+    nodes = CategoryHelp.objects.filter(is_published=True)
     if category is not None:
         context = HelpPage.objects.filter(category__url_tag="/" + category, category__is_published=True).first()
         if context:
             return render(request, "help/help.html", {"context": context, "nodes": nodes})
     url_redirect = request.META.get('HTTP_REFERER')
     try:
-        url_tag = re.search(r"(?<=drevo)/\w+|/$", url_redirect).group(0)
+        try:
+            url_tag = re.search(r"(?<=drevo)/\w+|/$", url_redirect).group(0)
+        except AttributeError:
+            context = HelpPage.objects.filter(category__url_tag='/', category__is_published=True).first()
+            return render(request, "help/help.html", {"context": context, "nodes": nodes})
         context = HelpPage.objects.filter(category__url_tag=url_tag, category__is_published=True).first()
         if context:
             return render(request, "help/help.html", {"context": context, "nodes": nodes})


### PR DESCRIPTION
1. Проблема. Не происходит переход из корня дерева "Оглавление помощи) - не находится страница.
2. При выдаче страницы помощи реквизит "Содержание" выдается как HTML-текст
3. Проблема. Неопубликованные категории все равно выдаются в оглавлении. Условие формулировалось чуть иначе, поскольку реквизит "Опубликовано" перенесен в другую таблицу. Но результат необходим по сути тот же.