### PR TITLE
Ограничил возможность выбора статусов на странице Работа админа по вопросу

### DIFF
--- a/drevo/forms/admin_interview_work_form.py
+++ b/drevo/forms/admin_interview_work_form.py
@@ -23,8 +23,6 @@ class InterviewAnswerExpertProposalForms(forms.ModelForm):
             (None, '------'),
             ("APPRVE", "Принят"),
             ("REJECT", "Не принят"),
-            ("ANSDPL", "Дубль. отв."),
-            ("RESDPL", "Дубль. предл."),
         ]
         self.old_status = self.instance.status
         self.old_comment = self.instance.admin_comment
@@ -35,3 +33,7 @@ class InterviewAnswerExpertProposalForms(forms.ModelForm):
         if self.instance.status:
             self.fields['admin_comment'].widget.attrs['disabled'] = 'true'
             self.fields['status'].widget.attrs['disabled'] = 'true'
+            if self.instance.status == 'ANSDPL':
+                self.fields['status'].choices += [("ANSDPL", "Дубль. отв.")]
+            elif self.instance.status == 'RESDPL':
+                self.fields['status'].choices += [("RESDPL", "Дубль. предл.")]

--- a/drevo/templates/email_templates/interview_result_email/base_interview_result_email.html
+++ b/drevo/templates/email_templates/interview_result_email/base_interview_result_email.html
@@ -6,7 +6,7 @@
 </head>
 <body>
     <div>
-        <h1>Уважаемый {{ expert.first_name }} {{ expert.last_name }}!</h1>
+        <h1>Уважаемый {{ expert.first_name }} {{ expert.profile.patronymic }}!</h1>
     </div>
     <div>
         <p>

--- a/drevo/templates/email_templates/interview_result_email/interview_new_answer_email.html
+++ b/drevo/templates/email_templates/interview_result_email/interview_new_answer_email.html
@@ -6,7 +6,7 @@
 </head>
 <body>
     <div>
-        <h1>Уважаемый {{ expert.first_name }} {{ expert.last_name }}!</h1>
+        <h1>Уважаемый {{ expert.first_name }} {{ expert.profile.patronymic }}!</h1>
     </div>
     <div>
         <p>

--- a/drevo/views/admin_interview_work/views.py
+++ b/drevo/views/admin_interview_work/views.py
@@ -207,7 +207,7 @@ def question_admin_work_view(request, inter_pk, quest_pk):
                     'ANSDPL': send_duplicate_answer_proposal,
                     'RESDPL': send_duplicate_proposal
                 }
-                # Занести все функции в словарь и ключами сделать статус
+
                 if obj.status in send_if_status.keys():
                     send_func = send_if_status.get(obj.status)
                     send_func(proposal_obj=obj)


### PR DESCRIPTION
## Изменения:
1. В выпадающем списке статусы "Дубль. отв." и "Дубль. предл." не отображаются до тех пор пока не будут установлены автоматически.
2. В сообщениях с результатом ответа на интервью обращение к эксперту происходит по Имени и Отчеству.